### PR TITLE
Add Sun Grid Engine, tests, and examples

### DIFF
--- a/mkwind/builder/settings.py
+++ b/mkwind/builder/settings.py
@@ -79,6 +79,10 @@ class JobSettings(BaseSettings):
         None,
         description="Total memory per CPU allocated for the job",
     )
+    extra_args: Optional[str] = Field(
+        None,
+        description="Extra arguments to pass to the script",
+    )
 
     pre_cmd: Optional[str] = Field(
         None,

--- a/mkwind/schedulers/__init__.py
+++ b/mkwind/schedulers/__init__.py
@@ -2,9 +2,11 @@ from .base import Scheduler, SchedulerJob, SchedulerError
 from .slurm import SlurmScheduler
 from .pueue import PueueScheduler
 from .lsf import LsfScheduler
+from .sge import SGEScheduler
 
 SCHEDULERS_CLS = {
     "slurm": SlurmScheduler,
     "pueue": PueueScheduler,
     "lsf": LsfScheduler
+    "sge": SGEScheduler
 }

--- a/mkwind/schedulers/__init__.py
+++ b/mkwind/schedulers/__init__.py
@@ -7,6 +7,6 @@ from .sge import SGEScheduler
 SCHEDULERS_CLS = {
     "slurm": SlurmScheduler,
     "pueue": PueueScheduler,
-    "lsf": LsfScheduler
+    "lsf": LsfScheduler,
     "sge": SGEScheduler
 }

--- a/mkwind/schedulers/sge.py
+++ b/mkwind/schedulers/sge.py
@@ -1,0 +1,121 @@
+import os
+from enum import Enum
+from typing import List
+
+from mkwind.jobs.dirmanager import TemporaryChdir
+from mkwind.templates import Template
+
+from .base import Scheduler, SchedulerJob
+
+
+def parse_qacct(output):
+    """
+    Parses the input text and returns a list of dictionaries.
+    Each block of text is separated by lines containing "=" characters.
+    The last four lines of the text are ignored.
+    """
+    text = text.strip().split("\n")
+    text = "\n".join(lines[:-4])
+    blocks = _split_into_blocks(text)
+    parsed_blocks = [_parse_block(block) for block in blocks]
+    return parsed_blocks
+
+
+def _split_into_blocks(text):
+    """Splits the text into blocks separated by lines of '='."""
+    lines = text.strip().split("\n")
+    blocks = []
+    current_block = []
+    for line in lines:
+        if line.strip().startswith("="):
+            if current_block:
+                blocks.append("\n".join(current_block))
+                current_block = []
+        else:
+            current_block.append(line)
+    if current_block:
+        blocks.append("\n".join(current_block))
+    return blocks
+
+
+def _parse_block(block_text):
+    """Parses a single block of text into a dictionary."""
+    block_dict = {}
+    for line in block_text.strip().split("\n"):
+        if line.strip():
+            parts = line.strip().split(None, 1)
+            if len(parts) == 2:
+                key, value = parts
+                block_dict[key] = value
+    return block_dict
+
+
+class SGEScheduler(Scheduler):
+    TEMPLATE = Template.from_name("slurm.sh")
+    SUBMIT_CMD = "qsub"
+    STATUS_CMD = "qstat -xml"
+    LOG_CMD = "qacct -d 1"
+    STATUS_TAGS = {
+        "id": "JB_job_number",
+        "name": "JB_name",
+        "start_time": "JAT_start_time",
+        "group": "queue_name",
+        "status": "state",
+    }
+
+    def submit_job(self, job_folder: os.PathLike):
+        name = os.path.basename(job_folder)
+        with TemporaryChdir(to=job_folder):
+            cmd = f"{self.SUBMIT_CMD} --job-name={name} {self.TEMPLATE.FILENAME}"
+            out = self._run(cmd)
+
+        return out
+
+    @property
+    def user_filter(self):
+        return f"-u {self.settings.USER}"
+
+    @property
+    def backlog(self):
+        return f"{self.LOG_CMD} -o {self.settings.USER}"
+
+    def get_all(self) -> List[SchedulerJob]:
+        cmd = f"{self.STATUS_CMD} {self.user_filter}"
+        out = self._run(cmd)
+        return self.format_output(out)
+
+    def get_queued(self) -> List[SchedulerJob]:
+        return self.get_pending()
+
+    def get_pending(self) -> List[SchedulerJob]:
+        cmd = f"{self.STATUS_CMD} {self.user_filter} -s ps"
+        out = self._run(cmd)
+        return self.format_output(out)
+
+    def get_running(self) -> List[SchedulerJob]:
+        cmd = f"{self.STATUS_CMD} {self.user_filter} -s r"
+        out = self._run(cmd)
+        return self.format_output(out)
+
+    def get_done(self) -> List[SchedulerJob]:
+        cmd = f"{self.backlog}"
+        out = self._run(cmd)
+        jobs = self.format_output(out)
+        return [job for job in jobs if job["failed"] == "0"]
+
+    def get_error(self) -> List[SchedulerJob]:
+        return self.get_failed()
+
+    def get_failed(self) -> List[SchedulerJob]:
+        cmd = f"{self.backlog}"
+        out = self._run(cmd)
+        jobs = self.format_output(out)
+        return [job for job in jobs if job["failed"] != "0"]
+
+    def format_output(self, out) -> List[SchedulerJob]:
+        root = ET.fromstring(xml_string)
+        jobs = [
+            {name: job.findtext(tag) for name, tag in self.STATUS_TAGS.items()}
+            for job in root.findall(".//job_list")
+        ]
+        return [SchedulerJob(**jdict) for jdict in jobs]

--- a/mkwind/schedulers/sge.py
+++ b/mkwind/schedulers/sge.py
@@ -1,6 +1,7 @@
 import os
 from enum import Enum
 from typing import List
+from xml.etree import ElementTree as ET
 
 from mkwind.jobs.dirmanager import TemporaryChdir
 from mkwind.templates import Template
@@ -113,7 +114,7 @@ class SGEScheduler(Scheduler):
         return [job for job in jobs if job["failed"] != "0"]
 
     def format_output(self, out) -> List[SchedulerJob]:
-        root = ET.fromstring(xml_string)
+        root = ET.fromstring(out)
         jobs = [
             {name: job.findtext(tag) for name, tag in self.STATUS_TAGS.items()}
             for job in root.findall(".//job_list")

--- a/mkwind/schedulers/sge.py
+++ b/mkwind/schedulers/sge.py
@@ -9,14 +9,14 @@ from mkwind.templates import Template
 from .base import Scheduler, SchedulerJob
 
 
-def parse_qacct(output):
+def parse_qacct(text):
     """
     Parses the input text and returns a list of dictionaries.
     Each block of text is separated by lines containing "=" characters.
     The last four lines of the text are ignored.
     """
     text = text.strip().split("\n")
-    text = "\n".join(lines[:-4])
+    text = "\n".join(text[:-4])
     blocks = _split_into_blocks(text)
     parsed_blocks = [_parse_block(block) for block in blocks]
     return parsed_blocks
@@ -101,7 +101,7 @@ class SGEScheduler(Scheduler):
     def get_done(self) -> List[SchedulerJob]:
         cmd = f"{self.backlog}"
         out = self._run(cmd)
-        jobs = self.format_output(out)
+        jobs = parse_qacct(out)
         return [job for job in jobs if job["failed"] == "0"]
 
     def get_error(self) -> List[SchedulerJob]:
@@ -110,7 +110,7 @@ class SGEScheduler(Scheduler):
     def get_failed(self) -> List[SchedulerJob]:
         cmd = f"{self.backlog}"
         out = self._run(cmd)
-        jobs = self.format_output(out)
+        jobs = parse_qacct(out)
         return [job for job in jobs if job["failed"] != "0"]
 
     def format_output(self, out) -> List[SchedulerJob]:

--- a/mkwind/schedulers/sge.py
+++ b/mkwind/schedulers/sge.py
@@ -19,7 +19,7 @@ def parse_qacct(text):
     text = "\n".join(text[:-4])
     blocks = _split_into_blocks(text)
     parsed_blocks = [_parse_block(block) for block in blocks]
-    return parsed_blocks
+    return [blk for blk in parsed_blocks if blk]
 
 
 def _split_into_blocks(text):
@@ -67,7 +67,7 @@ class SGEScheduler(Scheduler):
     def submit_job(self, job_folder: os.PathLike):
         name = os.path.basename(job_folder)
         with TemporaryChdir(to=job_folder):
-            cmd = f"{self.SUBMIT_CMD} --job-name={name} {self.TEMPLATE.FILENAME}"
+            cmd = f"{self.SUBMIT_CMD} -N {name} {self.TEMPLATE.FILENAME}"
             out = self._run(cmd)
 
         return out

--- a/mkwind/schedulers/sge.py
+++ b/mkwind/schedulers/sge.py
@@ -51,7 +51,7 @@ def _parse_block(block_text):
 
 
 class SGEScheduler(Scheduler):
-    TEMPLATE = Template.from_name("slurm.sh")
+    TEMPLATE = Template.from_name("sge.sh")
     SUBMIT_CMD = "qsub"
     STATUS_CMD = "qstat -xml"
     LOG_CMD = "qacct -d 1"

--- a/mkwind/schedulers/tests/files/sge_qacct.txt
+++ b/mkwind/schedulers/tests/files/sge_qacct.txt
@@ -1,0 +1,112 @@
+==============================================================
+qname        compute_pool.q
+hostname     node5678
+group        bioinformatics_team
+owner        user_alpha
+project      genome_analysis_project
+department   bio_dept
+jobname      task01_genome_stats
+jobnumber    7890123
+taskid       101
+pe_taskid    NONE
+account      compute_account1
+priority     0
+cwd          /data/users/user_alpha/projects/genome_analysis/workdir
+submit_host  host1234
+submit_cmd   run_job -t 1-256 Scripts/task01_genome_stats.job
+qsub_time    11/18/2024 11:11:55.829
+start_time   11/18/2024 13:51:22.711
+end_time     11/18/2024 13:51:25.563
+granted_pe   NONE
+slots        1
+failed       0
+deleted_by   NONE
+exit_status  0
+ru_wallclock 2.852
+ru_utime     1.402
+ru_stime     0.955
+ru_maxrss    8372
+ru_ixrss     0
+ru_ismrss    0
+ru_idrss     0
+ru_isrss     0
+ru_minflt    186306
+ru_majflt    0
+ru_nswap     0
+ru_inblock   6512
+ru_oublock   9200
+ru_msgsnd    0
+ru_msgrcv    0
+ru_nsignals  0
+ru_nvcsw     3830
+ru_nivcsw    396
+wallclock    3.163
+cpu          2.357
+mem          0.003
+io           0.255
+iow          0.020
+ioops        28777
+maxvmem      16.051M
+maxrss       0.000
+maxpss       0.000
+arid         undefined
+jc_name      NONE
+bound_cores  NONE
+==============================================================
+qname        analysis_queue.q
+hostname     node9876
+group        data_science_team
+owner        user_beta
+project      climate_modeling_project
+department   analytics_dept
+jobname      simulation_run02
+jobnumber    3456789
+taskid       205
+pe_taskid    NONE
+account      compute_account2
+priority     0
+cwd          /workdir/data_science_team/user_beta/climate_modeling/simulation_run02
+submit_host  host5678
+submit_cmd   execute_job -t 1-512 Scripts/simulation_run02.job
+qsub_time    11/18/2024 12:34:45.123
+start_time   11/18/2024 14:15:22.711
+end_time     11/18/2024 14:16:25.563
+granted_pe   NONE
+slots        1
+failed       0
+deleted_by   NONE
+exit_status  0
+ru_wallclock 3.125
+ru_utime     1.512
+ru_stime     1.007
+ru_maxrss    9210
+ru_ixrss     0
+ru_ismrss    0
+ru_idrss     0
+ru_isrss     0
+ru_minflt    195306
+ru_majflt    0
+ru_nswap     0
+ru_inblock   7200
+ru_oublock   11000
+ru_msgsnd    0
+ru_msgrcv    0
+ru_nsignals  0
+ru_nvcsw     3900
+ru_nivcsw    402
+wallclock    4.013
+cpu          2.873
+mem          0.004
+io           0.290
+iow          0.025
+ioops        29800
+maxvmem      18.512M
+maxrss       0.000
+maxpss       0.000
+arid         undefined
+jc_name      NONE
+bound_cores  NONE
+Total System Usage
+    WALLCLOCK         UTIME         STIME           CPU             MEMORY                 IO                IOW
+================================================================================================================
+    126280387 179584914.604  22937278.963 220362353.074     3418617641.413        2478173.064         888216.290

--- a/mkwind/schedulers/tests/files/sge_qacct.txt
+++ b/mkwind/schedulers/tests/files/sge_qacct.txt
@@ -106,6 +106,60 @@ maxpss       0.000
 arid         undefined
 jc_name      NONE
 bound_cores  NONE
+==============================================================
+qname        render_queue.q
+hostname     render_node2023
+group        graphics_team
+owner        user_gamma
+project      3d_rendering_project
+department   design_dept
+jobname      render_scene05
+jobnumber    9876543
+taskid       307
+pe_taskid    NONE
+account      compute_account3
+priority     0
+cwd          /projects/graphics_team/user_gamma/3d_rendering/scenes/render_scene05
+submit_host  host9012
+submit_cmd   render_task -t 1-64 Scripts/render_scene05.job
+qsub_time    11/18/2024 14:22:15.987
+start_time   11/18/2024 16:02:10.123
+end_time     11/18/2024 16:03:05.456
+granted_pe   NONE
+slots        1
+failed       1
+deleted_by   NONE
+exit_status  1
+ru_wallclock 0.932
+ru_utime     0.562
+ru_stime     0.331
+ru_maxrss    12456
+ru_ixrss     0
+ru_ismrss    0
+ru_idrss     0
+ru_isrss     0
+ru_minflt    86432
+ru_majflt    12
+ru_nswap     0
+ru_inblock   2100
+ru_oublock   5120
+ru_msgsnd    0
+ru_msgrcv    0
+ru_nsignals  0
+ru_nvcsw     1502
+ru_nivcsw    170
+wallclock    1.123
+cpu          0.893
+mem          0.005
+io           0.089
+iow          0.015
+ioops        8320
+maxvmem      12.004M
+maxrss       0.000
+maxpss       0.000
+arid         undefined
+jc_name      NONE
+bound_cores  NONE
 Total System Usage
     WALLCLOCK         UTIME         STIME           CPU             MEMORY                 IO                IOW
 ================================================================================================================

--- a/mkwind/schedulers/tests/files/sge_qstat.xml
+++ b/mkwind/schedulers/tests/files/sge_qstat.xml
@@ -1,0 +1,51 @@
+<?xml version='1.0'?>
+<job_info  xmlns:xsd="http://www.univa.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <queue_info>
+    <job_list state="running">
+      <JB_job_number>1</JB_job_number>
+      <JAT_prio>0.60000</JAT_prio>
+      <JB_name>job1.sh</JB_name>
+      <JB_owner>user1</JB_owner>
+      <state>r</state>
+      <JAT_start_time>2024-11-18T01:01:26.969</JAT_start_time>
+      <queue_name>queue@node</queue_name>
+      <jclass_name></jclass_name>
+      <slots>256</slots>
+    </job_list>
+    <job_list state="running">
+      <JB_job_number>2</JB_job_number>
+      <JAT_prio>0.60000</JAT_prio>
+      <JB_name>job2.sh</JB_name>
+      <JB_owner>user1</JB_owner>
+      <state>r</state>
+      <JAT_start_time>2024-11-18T05:35:58.379</JAT_start_time>
+      <queue_name>queue@node</queue_name>
+      <jclass_name></jclass_name>
+      <slots>256</slots>
+    </job_list>
+    <job_list state="pending">
+      <JB_job_number>3</JB_job_number>
+      <JAT_prio>0.59834</JAT_prio>
+      <JB_name>job3.sh</JB_name>
+      <JB_owner>user1</JB_owner>
+      <state>r</state>
+      <JAT_start_time>2024-11-19T00:01:48.124</JAT_start_time>
+      <queue_name>queue@node</queue_name>
+      <jclass_name></jclass_name>
+      <slots>256</slots>
+    </job_list>
+    <job_list state="pending">
+      <JB_job_number>4</JB_job_number>
+      <JAT_prio>0.54180</JAT_prio>
+      <JB_name>job4.sh</JB_name>
+      <JB_owner>user2</JB_owner>
+      <state>r</state>
+      <JAT_start_time>2024-07-15T09:59:52.118</JAT_start_time>
+      <queue_name>queue2@node</queue_name>
+      <jclass_name></jclass_name>
+      <slots>2</slots>
+    </job_list>
+  </queue_info>
+  <job_info>
+  </job_info>
+</job_info>

--- a/mkwind/schedulers/tests/files/sge_qstat_p.xml
+++ b/mkwind/schedulers/tests/files/sge_qstat_p.xml
@@ -1,0 +1,40 @@
+<?xml version='1.0'?>
+<job_info  xmlns:xsd="http://www.univa.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <queue_info>
+    <job_list state="pending">
+      <JB_job_number>3</JB_job_number>
+      <JAT_prio>0.59834</JAT_prio>
+      <JB_name>job3.sh</JB_name>
+      <JB_owner>user1</JB_owner>
+      <state>p</state>
+      <JAT_start_time>2024-11-19T00:01:48.124</JAT_start_time>
+      <queue_name>queue@node</queue_name>
+      <jclass_name></jclass_name>
+      <slots>256</slots>
+    </job_list>
+    <job_list state="pending">
+      <JB_job_number>4</JB_job_number>
+      <JAT_prio>0.54180</JAT_prio>
+      <JB_name>job4.sh</JB_name>
+      <JB_owner>user2</JB_owner>
+      <state>p</state>
+      <JAT_start_time>2024-07-15T09:59:52.118</JAT_start_time>
+      <queue_name>queue2@node</queue_name>
+      <jclass_name></jclass_name>
+      <slots>2</slots>
+    </job_list>
+    <job_list state="pending">
+      <JB_job_number>5</JB_job_number>
+      <JAT_prio>0.6841</JAT_prio>
+      <JB_name>job5.sh</JB_name>
+      <JB_owner>user4</JB_owner>
+      <state>p</state>
+      <JAT_start_time>2024-07-15T11:20:17.318</JAT_start_time>
+      <queue_name>queue5@node1232</queue_name>
+      <jclass_name></jclass_name>
+      <slots>8</slots>
+    </job_list>
+  </queue_info>
+  <job_info>
+  </job_info>
+</job_info>

--- a/mkwind/schedulers/tests/files/sge_qstat_r.xml
+++ b/mkwind/schedulers/tests/files/sge_qstat_r.xml
@@ -23,28 +23,6 @@
       <jclass_name></jclass_name>
       <slots>256</slots>
     </job_list>
-    <job_list state="pending">
-      <JB_job_number>3</JB_job_number>
-      <JAT_prio>0.59834</JAT_prio>
-      <JB_name>job3.sh</JB_name>
-      <JB_owner>user1</JB_owner>
-      <state>r</state>
-      <JAT_start_time>2024-11-19T00:01:48.124</JAT_start_time>
-      <queue_name>queue@node</queue_name>
-      <jclass_name></jclass_name>
-      <slots>256</slots>
-    </job_list>
-    <job_list state="pending">
-      <JB_job_number>4</JB_job_number>
-      <JAT_prio>0.54180</JAT_prio>
-      <JB_name>job4.sh</JB_name>
-      <JB_owner>user2</JB_owner>
-      <state>r</state>
-      <JAT_start_time>2024-07-15T09:59:52.118</JAT_start_time>
-      <queue_name>queue2@node</queue_name>
-      <jclass_name></jclass_name>
-      <slots>2</slots>
-    </job_list>
   </queue_info>
   <job_info>
   </job_info>

--- a/mkwind/schedulers/tests/test_sge.py
+++ b/mkwind/schedulers/tests/test_sge.py
@@ -13,7 +13,7 @@ from mkite_core.tests.tempdirs import run_in_tempdir
 
 SETTINGS = resource_filename("mkwind.tests.files", "settings.yaml")
 QACCT_FILE = resource_filename("mkwind.schedulers.tests.files", "sge_qacct.txt")
-QSTAT_FILE = resource_filename("mkwind.schedulers.tests.files", "sge_qstat.txt")
+QSTAT_FILE = resource_filename("mkwind.schedulers.tests.files", "sge_qstat.xml")
 
 
 class MockSGEScheduler(SGEScheduler):

--- a/mkwind/schedulers/tests/test_sge.py
+++ b/mkwind/schedulers/tests/test_sge.py
@@ -1,0 +1,53 @@
+import os
+from pathlib import Path
+from pkg_resources import resource_filename
+
+import unittest as ut
+from unittest.mock import patch
+
+from mkwind.user import EnvSettings
+from mkwind.schedulers.base import SchedulerJob
+from mkwind.schedulers.sge import SGEScheduler
+from mkite_core.tests.tempdirs import run_in_tempdir
+
+
+SETTINGS = resource_filename("mkwind.tests.files", "settings.yaml")
+QACCT_FILE = resource_filename("mkwind.schedulers.tests.files", "sge_qacct.txt")
+QSTAT_FILE = resource_filename("mkwind.schedulers.tests.files", "sge_qstat.txt")
+
+
+class MockSGEScheduler(SGEScheduler):
+    SUBMIT_CMD = "echo"
+
+    def _run(self, cmd):
+        if "qstat" in cmd:
+            return self.qstat
+
+        if "qacct" in cmd:
+            return self.qacct
+
+    @property
+    def qacct(self):
+        with open(QACCT_FILE, "r") as f:
+            out = f.read()
+
+        return out
+
+    @property
+    def qstat(self):
+        with open(QSTAT_FILE, "r") as f:
+            out = f.read()
+
+        return out
+
+
+class TestSGEScheduler(ut.TestCase):
+    def setUp(self):
+        settings = EnvSettings.from_file(SETTINGS)
+        self.sched = MockSGEScheduler(settings=settings)
+
+    def test_gets(self):
+        self.assertEqual(len(self.sched.get_running()), 2)
+        self.assertEqual(len(self.sched.get_pending()), 2)
+        self.assertEqual(len(self.sched.get_done()), 2)
+        self.assertEqual(len(self.sched.get_error()), 0)

--- a/mkwind/templates/sge.sh
+++ b/mkwind/templates/sge.sh
@@ -1,0 +1,56 @@
+#!/bin/bash -l
+
+{% if job.nodes -%}
+#SBATCH --nodes={{ job.nodes }}
+{% endif %}
+{%- if job.ntasks -%}
+#SBATCH --ntasks={{ job.ntasks }}
+{% endif %}
+{%- if job.tasks_per_node -%}
+#SBATCH --ntasks-per-node={{ job.tasks_per_node }}
+{% endif %}
+{%- if job.cpus_per_task -%}
+#SBATCH --cpus-per-task={{ job.cpus_per_task }}
+{% endif %}
+{%- if job.gpus_per_task -%}
+#SBATCH --gpus-per-task={{ job.gpus_per_task }}
+{% endif %}
+{%- if job.gpus_per_node -%}
+#SBATCH --gpus-per-node={{ job.gpus_per_node }}
+{% endif %}
+{%- if job.gres -%}
+#SBATCH --gres={{ job.gres }}
+{% endif %}
+{%- if job.gpus -%}
+#SBATCH --gpus={{ job.gpus }}
+{% endif %}
+{%- if job.walltime -%}
+#SBATCH --time={{ job.walltime }}
+{% endif %}
+{%- if job.partition -%}
+#SBATCH --partition={{ job.partition }}
+{% endif %}
+{%- if job.account -%}
+#SBATCH --account={{ job.account }}
+{% endif %}
+{%- if name -%}
+#SBATCH --job-name={{ name }}
+#SBATCH --output={{ name }}-%j.out
+#SBATCH --error={{ name }}-%j.error
+{% endif %}
+{%- if job.memory -%}
+#SBATCH --mem={{ job.memory }}
+{% endif %}
+{%- if job.memory_per_cpu -%}
+#SBATCH --mem-per-cpu={{ job.memory_per_cpu }}
+{% endif %}
+
+{%- if job.pre_cmd -%}
+{{ job.pre_cmd }}
+{% endif %}
+{%- if job.cmd -%}
+{{ job.cmd }}
+{% endif %}
+{%- if job.post_cmd -%}
+{{ job.post_cmd }}
+{% endif %}

--- a/mkwind/templates/sge.sh
+++ b/mkwind/templates/sge.sh
@@ -13,22 +13,22 @@
 #$ -pe smp {{ job.cpus_per_task }}
 {% endif %}
 {%- if job.gpus_per_task -%}
-#$ -l gpu={{ job.gpus_per_task }}
+#$ -l gpu,cuda={{ job.gpus_per_task }}
 {% endif %}
 {%- if job.gpus_per_node -%}
-#$ -l gpu_per_node={{ job.gpus_per_node }}
+#$ -l gpu,cuda={{ job.gpus_per_node }}
 {% endif %}
 {%- if job.gres -%}
-#$ -l gres={{ job.gres }}
+#$ -l gpu,cuda={{ job.gres }}
 {% endif %}
 {%- if job.gpus -%}
-#$ -l gpus={{ job.gpus }}
+#$ -l gpu,cuda={{ job.gpus }}
 {% endif %}
 {%- if job.walltime -%}
 #$ -l h_rt={{ job.walltime }}
 {% endif %}
 {%- if job.partition -%}
-#$ -q {{ job.partition }}
+#$ -l {{ job.partition }}
 {% endif %}
 {%- if job.account -%}
 #$ -A {{ job.account }}
@@ -39,10 +39,10 @@
 #$ -e {{ name }}-$JOB_ID.error
 {% endif %}
 {%- if job.memory -%}
-#$ -l mem={{ job.memory }}
+#$ -l h_vmem={{ job.memory }}
 {% endif %}
 {%- if job.memory_per_cpu -%}
-#$ -l mem_per_core={{ job.memory_per_cpu }}
+#$ -l h_data={{ job.memory_per_cpu }}
 {% endif %}
 
 {%- if job.pre_cmd -%}

--- a/mkwind/templates/sge.sh
+++ b/mkwind/templates/sge.sh
@@ -7,8 +7,7 @@
 #$ -pe smp {{ job.ntasks }}
 {% endif %}
 {%- if job.tasks_per_node -%}
-#$ -binding linear:{{ job.tasks_per_node }}
-#$ -pe shared
+#$ -pe shared {{ job.tasks_per_node }}
 {% endif %}
 {%- if job.cpus_per_task -%}
 #$ -pe smp {{ job.cpus_per_task }}

--- a/mkwind/templates/sge.sh
+++ b/mkwind/templates/sge.sh
@@ -8,6 +8,7 @@
 {% endif %}
 {%- if job.tasks_per_node -%}
 #$ -binding linear:{{ job.tasks_per_node }}
+#$ -pe shared
 {% endif %}
 {%- if job.cpus_per_task -%}
 #$ -pe smp {{ job.cpus_per_task }}
@@ -43,6 +44,9 @@
 {% endif %}
 {%- if job.memory_per_cpu -%}
 #$ -l h_data={{ job.memory_per_cpu }}
+{% endif %}
+{%- if job.extra_args -%}
+#$ {{ job.extra_args }}
 {% endif %}
 
 {%- if job.pre_cmd -%}

--- a/mkwind/templates/sge.sh
+++ b/mkwind/templates/sge.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -l
-
+#$ -cwd
 {% if job.nodes -%}
 #$ -l nodes={{ job.nodes }}
 {% endif %}
@@ -36,7 +36,7 @@
 {%- if name -%}
 #$ -N {{ name }}
 #$ -o {{ name }}-$JOB_ID.out
-#$ -e {{ name }}-$JOB_ID.error
+#$ -e {{ name }}-$JOB_ID.err
 {% endif %}
 {%- if job.memory -%}
 #$ -l h_vmem={{ job.memory }}

--- a/mkwind/templates/sge.sh
+++ b/mkwind/templates/sge.sh
@@ -1,48 +1,48 @@
 #!/bin/bash -l
 
 {% if job.nodes -%}
-#SBATCH --nodes={{ job.nodes }}
+#$ -l nodes={{ job.nodes }}
 {% endif %}
 {%- if job.ntasks -%}
-#SBATCH --ntasks={{ job.ntasks }}
+#$ -pe smp {{ job.ntasks }}
 {% endif %}
 {%- if job.tasks_per_node -%}
-#SBATCH --ntasks-per-node={{ job.tasks_per_node }}
+#$ -binding linear:{{ job.tasks_per_node }}
 {% endif %}
 {%- if job.cpus_per_task -%}
-#SBATCH --cpus-per-task={{ job.cpus_per_task }}
+#$ -pe smp {{ job.cpus_per_task }}
 {% endif %}
 {%- if job.gpus_per_task -%}
-#SBATCH --gpus-per-task={{ job.gpus_per_task }}
+#$ -l gpu={{ job.gpus_per_task }}
 {% endif %}
 {%- if job.gpus_per_node -%}
-#SBATCH --gpus-per-node={{ job.gpus_per_node }}
+#$ -l gpu_per_node={{ job.gpus_per_node }}
 {% endif %}
 {%- if job.gres -%}
-#SBATCH --gres={{ job.gres }}
+#$ -l gres={{ job.gres }}
 {% endif %}
 {%- if job.gpus -%}
-#SBATCH --gpus={{ job.gpus }}
+#$ -l gpus={{ job.gpus }}
 {% endif %}
 {%- if job.walltime -%}
-#SBATCH --time={{ job.walltime }}
+#$ -l h_rt={{ job.walltime }}
 {% endif %}
 {%- if job.partition -%}
-#SBATCH --partition={{ job.partition }}
+#$ -q {{ job.partition }}
 {% endif %}
 {%- if job.account -%}
-#SBATCH --account={{ job.account }}
+#$ -A {{ job.account }}
 {% endif %}
 {%- if name -%}
-#SBATCH --job-name={{ name }}
-#SBATCH --output={{ name }}-%j.out
-#SBATCH --error={{ name }}-%j.error
+#$ -N {{ name }}
+#$ -o {{ name }}-$JOB_ID.out
+#$ -e {{ name }}-$JOB_ID.error
 {% endif %}
 {%- if job.memory -%}
-#SBATCH --mem={{ job.memory }}
+#$ -l mem={{ job.memory }}
 {% endif %}
 {%- if job.memory_per_cpu -%}
-#SBATCH --mem-per-cpu={{ job.memory_per_cpu }}
+#$ -l mem_per_core={{ job.memory_per_cpu }}
 {% endif %}
 
 {%- if job.pre_cmd -%}


### PR DESCRIPTION
Add the Sun Grid Engine (SGE) for mkwind so it can run on UCLA's Hoffman2.

AI-generated summary:

This pull request adds support for the SGE (Sun Grid Engine) scheduler in the `mkwind` package. The most important changes include the addition of the `SGEScheduler` class, updates to the scheduler initialization, and the creation of test cases and templates.

### SGE Scheduler Support:

* [`mkwind/schedulers/sge.py`](diffhunk://#diff-12bc0fb4f13995ddcc33a02af346068515bb94e667dd5caff81014592952f7fdR1-R139): Added the `SGEScheduler` class with methods for job submission, status checking, and job formatting. This includes helper functions for parsing `qacct` output and formatting job information.
* [`mkwind/schedulers/__init__.py`](diffhunk://#diff-0d437771b6b24f441b4df1cb6a47cd43daf1b57bd71e15b5ba666dd773253da8R5-R11): Included the `SGEScheduler` in the list of available schedulers.

### Configuration and Templates:

* [`mkwind/builder/settings.py`](diffhunk://#diff-115c5bb8811f5376e6cb013cc6f6a39501e6cb2c09be7b9644c7b8ea95b6dff5R82-R85): Added a new field `extra_args` to `JobSettings` for passing additional arguments to the script.
* [`mkwind/templates/sge.sh`](diffhunk://#diff-e81a6be284c3f4a58076c9f59418139f60eba271a9b1319c4fde399ec06303ecR1-R59): Created a new template for SGE job scripts, including various job configuration options.

### Testing:

* [`mkwind/schedulers/tests/test_sge.py`](diffhunk://#diff-8888ca9c87ba452171b93b28752604fc7525fa7b8bb3a47b46982cc7177e641aR1-R51): Added unit tests for the `SGEScheduler` class, including mock data for running and pending jobs and `qacct` output.
* [`mkwind/schedulers/tests/files/sge_qacct.txt`](diffhunk://#diff-8011d2d3b949ce24d17567c4022df720b62bd346d74bd8a3090a5ece4bcc4c64R1-R166): Added sample `qacct` output file for testing job accounting information.
* [`mkwind/schedulers/tests/files/sge_qstat_p.xml`](diffhunk://#diff-63837454c807b546ccae7c7c18dc75c81679710bcebedd6db4cd5117da68a7fdR1-R40): Added sample XML file for testing pending job status.
* [`mkwind/schedulers/tests/files/sge_qstat_r.xml`](diffhunk://#diff-a367174a46d8c1e6de6f227125272898145b56029eabda4a4f634d38b0d159f6R1-R29): Added sample XML file for testing running job status.